### PR TITLE
Feat/로그인적용

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,7 +10,7 @@ android {
 
     defaultConfig {
         applicationId "com.apptive.braini"
-        minSdk 29
+        minSdk 28
         targetSdk 32
         versionCode 1
         versionName "1.0"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.apptive.braini">
+    <uses-permission android:name="android.permission.INTERNET"/>
 
     <application
         android:name="com.example.braini.MainApplication"

--- a/app/src/main/java/com/example/braini/MainActivity.kt
+++ b/app/src/main/java/com/example/braini/MainActivity.kt
@@ -8,9 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.navigation.compose.rememberNavController
 import com.apptive.braini.ui.theme.LayoutPracticeTheme
-import com.apptive.braini.view.LoginScreen
 import com.example.braini.presentation.navigation.SetupNavGraph
-import com.example.braini.presentation.view.ModalBottomSheet
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -19,10 +17,8 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         setContent {
             LayoutPracticeTheme {
-                // A surface container using the 'background' color from the theme
                 val navController = rememberNavController()
                 SetupNavGraph(navController = navController)
-                ModalBottomSheet()
             }
         }
     }

--- a/app/src/main/java/com/example/braini/_constant/UIConstant.kt
+++ b/app/src/main/java/com/example/braini/_constant/UIConstant.kt
@@ -4,5 +4,6 @@ import androidx.compose.ui.unit.dp
 
 object UIConstant {
     val BUTTON_WIDTH_LONG = 250.dp
-    val BUTTOn_WIDTH_SMALL = 100.dp
+    val BUTTON_WIDTH_SMALL = 100.dp
+    val DURATION_SPLASH_MILLI = 4000
 }

--- a/app/src/main/java/com/example/braini/domain/utils/ConnectionResultHandler.kt
+++ b/app/src/main/java/com/example/braini/domain/utils/ConnectionResultHandler.kt
@@ -1,0 +1,20 @@
+package com.example.braini.domain.utils
+
+import android.content.Context
+import android.widget.Toast
+import com.google.android.gms.common.ConnectionResult.*
+import com.google.android.gms.common.GoogleApiAvailability
+
+object ConnectionResultHandler {
+    fun handleErrorCode(context: Context) {
+        val apiAvailability = GoogleApiAvailability.getInstance()
+        val resultCode = apiAvailability.isGooglePlayServicesAvailable(context)
+        val errorMessage = when(resultCode) {
+            CANCELED -> "인터넷 연결이 site."
+            SERVICE_INVALID -> "구글 플레이 버전이 유효하지 않습니다."
+            else -> "유효하지 않은 에러 코드"
+        }
+
+        Toast.makeText(context, "(코드: $resultCode) $errorMessage", Toast.LENGTH_LONG).show()
+    }
+}

--- a/app/src/main/java/com/example/braini/domain/utils/GoogleOneTap.kt
+++ b/app/src/main/java/com/example/braini/domain/utils/GoogleOneTap.kt
@@ -5,12 +5,14 @@ import android.content.Context
 import android.content.IntentSender
 import android.content.IntentSender.SendIntentException
 import android.util.Log
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.ManagedActivityResultLauncher
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.IntentSenderRequest
 import com.apptive.braini.R
+import com.example.braini.MainApplication
 import com.example.braini.domain.IntentSenderLauncher
 import com.example.braini.domain.log
 import com.example.braini.domain.model.Account
@@ -19,6 +21,8 @@ import com.google.android.gms.auth.api.identity.BeginSignInRequest.GoogleIdToken
 import com.google.android.gms.auth.api.identity.BeginSignInResult
 import com.google.android.gms.auth.api.identity.Identity
 import com.google.android.gms.auth.api.identity.SignInClient
+import com.google.android.gms.common.ConnectionResult
+import com.google.android.gms.common.GoogleApiAvailability
 import com.google.android.gms.tasks.OnSuccessListener
 import dagger.hilt.android.qualifiers.ActivityContext
 import dagger.hilt.android.scopes.ActivityScoped
@@ -37,7 +41,7 @@ class GoogleOneTap @Inject constructor(
         accountManager.logout()
     }
 
-    fun onActicityResult(result: ActivityResult) {
+    fun onActicityResult(result: ActivityResult, onSuccess: () -> Unit = {}) {
         when (result.resultCode) {
             Activity.RESULT_OK -> {
                 val credential = oneTapClient.getSignInCredentialFromIntent(result.data)
@@ -48,6 +52,8 @@ class GoogleOneTap @Inject constructor(
 
                 val account = Account(id=id, token=token, email=email, name=name)
                 accountManager.login(account)
+                Toast.makeText(MainApplication.context(), "{$name}님 안녕하세요!", Toast.LENGTH_SHORT).show()
+                onSuccess()
             }
             Activity.RESULT_CANCELED -> {
                 "One Tap Canceled!".log()
@@ -56,13 +62,16 @@ class GoogleOneTap @Inject constructor(
     }
 
     fun beginSignIn(
-        launcher: IntentSenderLauncher
+        launcher: IntentSenderLauncher,
     ) {
         val request = providesBeginSignIn()
 
         oneTapClient.beginSignIn(request)
             .addOnSuccessListener(onSuccessListener(launcher))
             .addOnFailureListener { e ->
+                val context = MainApplication.context()
+                val available = GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(context)
+                Toast.makeText(context, "Google Play: ${available}, ${e.localizedMessage}", Toast.LENGTH_SHORT).show()
                 "No Google Accounts found. Just continue presenting the signed-out UI.".log()
                 e.localizedMessage.log()
             }
@@ -90,7 +99,9 @@ class GoogleOneTap @Inject constructor(
     }
 
     /** Client 빌드가 성공적으로 완료된 이후 실행될 콜백 함수 */
-    private fun onSuccessListener(launcher: IntentSenderLauncher): OnSuccessListener<BeginSignInResult> {
+    private fun onSuccessListener(
+        launcher: IntentSenderLauncher
+    ): OnSuccessListener<BeginSignInResult> {
         return object: OnSuccessListener<BeginSignInResult> {
             override fun onSuccess(p0: BeginSignInResult) {
                 val senderRequest = IntentSenderRequest
@@ -100,6 +111,9 @@ class GoogleOneTap @Inject constructor(
                 try {
                     launcher.launch(senderRequest)
                 } catch (e: SendIntentException) {
+                    val context = MainApplication.context()
+                    val available = GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(context)
+                    Toast.makeText(context, "UI 호출 실패, ${e.localizedMessage}", Toast.LENGTH_SHORT).show()
                     "Couldn't start One Tap UI: ${e.localizedMessage}".log()
                 }
             }

--- a/app/src/main/java/com/example/braini/presentation/extension.kt
+++ b/app/src/main/java/com/example/braini/presentation/extension.kt
@@ -6,8 +6,17 @@ import android.content.ContextWrapper
 import androidx.activity.ComponentActivity
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
+import androidx.navigation.NavController
 
 @Composable
 fun requireContext(): Context = LocalContext.current
 
 fun Context.getActivity() = this as ComponentActivity
+
+fun NavController.popAndNavigate(route: String) {
+    this.popBackStack()
+    this.navigate(route) {
+        launchSingleTop = true
+        restoreState = true
+    }
+}

--- a/app/src/main/java/com/example/braini/presentation/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/braini/presentation/navigation/NavGraph.kt
@@ -15,7 +15,8 @@ import com.example.braini.presentation.view.AnimatedSplashScreen
 fun SetupNavGraph(navController: NavHostController){
     NavHost(
         navController =navController ,
-        startDestination = Screen.Splash.route){
+        startDestination = Screen.Splash.route
+    ){
         composable(route = Screen.Splash.route){
             AnimatedSplashScreen(navController)
         }

--- a/app/src/main/java/com/example/braini/presentation/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/braini/presentation/navigation/NavGraph.kt
@@ -1,15 +1,14 @@
 package com.example.braini.presentation.navigation
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.navigation.NavController
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import com.apptive.braini.view.LoginScreen
-import com.example.braini.presentation.view.AnimatedSplashScreen
+import com.apptive.braini.view.RoomSelectScreen
+import com.example.braini.presentation.view.SplashScreen
+import com.example.braini.presentation.viewmodel.LoginViewModel
 
 @Composable
 fun SetupNavGraph(navController: NavHostController){
@@ -17,11 +16,16 @@ fun SetupNavGraph(navController: NavHostController){
         navController =navController ,
         startDestination = Screen.Splash.route
     ){
-        composable(route = Screen.Splash.route){
-            AnimatedSplashScreen(navController)
+        composable(route = Screen.Splash.route) {
+            val viewModel = hiltViewModel<LoginViewModel>()
+            SplashScreen(viewModel, navController)
         }
-        composable(route = Screen.Login.route){
-            LoginScreen()
+        composable(route = Screen.Login.route) {
+            val viewModel = hiltViewModel<LoginViewModel>()
+            LoginScreen(viewModel, navController)
+        }
+        composable(route = Screen.RoomSelect.route) {
+            RoomSelectScreen()
         }
     }
 }

--- a/app/src/main/java/com/example/braini/presentation/navigation/Screen.kt
+++ b/app/src/main/java/com/example/braini/presentation/navigation/Screen.kt
@@ -3,4 +3,5 @@ package com.example.braini.presentation.navigation
 sealed class Screen(val route: String) {
     object Splash : Screen("screen_splash")
     object Login : Screen("screen_login")
+    object RoomSelect : Screen("screen_room_select")
 }

--- a/app/src/main/java/com/example/braini/presentation/view/Login.kt
+++ b/app/src/main/java/com/example/braini/presentation/view/Login.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
-import androidx.compose.material.ButtonColors
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -16,12 +15,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.ParagraphStyle
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -29,13 +24,8 @@ import com.apptive.braini.R
 
 @Composable
 fun LoginScreen(){
-    Column(modifier = Modifier
-        .fillMaxSize()
-        .background(
-            brush = Brush.verticalGradient(listOf(Color(55, 103, 706), Color(143, 171, 217))),
-            shape = RectangleShape
-        )) {
-        header()
+    LoginBackground {
+        Header()
         Clouds()
         Description()
         Buttons()
@@ -43,58 +33,101 @@ fun LoginScreen(){
 }
 
 @Composable
-private fun ColumnScope.header()
+private fun LoginBackground(
+    content: @Composable ColumnScope.() -> Unit = {}
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(
+                brush = Brush.verticalGradient(listOf(Color(55, 103, 706), Color(143, 171, 217))),
+                shape = RectangleShape
+            ),
+        content = content
+    )
+}
+
+@Composable
+private fun ColumnScope.Header()
 {
-    Text(modifier = Modifier
-        .width(200.dp)
-        .weight(0.7f)
-        .padding(20.dp)
-        .padding(top = 20.dp),
+    Text(
+        modifier = Modifier
+            .width(200.dp)
+            .weight(0.7f)
+            .padding(20.dp)
+            .padding(top = 20.dp),
         text = "Hello!",
         fontSize = 50.sp,
         color = Color.White,
-        textAlign = TextAlign.Center)
+        textAlign = TextAlign.Center
+    )
 }
 
 @Composable
 private fun ColumnScope.Clouds(){
-    Box(modifier = Modifier
-        .weight(2f)
-        .padding(top = 50.dp)){
-        Box(modifier = Modifier
-            .fillMaxSize()
-            .padding(start = 260.dp)){
-            Image(painter = painterResource(id = R.drawable.small_cloud),
+    Box(
+        modifier = Modifier
+            .weight(2f)
+            .padding(top = 50.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(start = 260.dp)
+        ){
+            Image(
+                modifier = Modifier.size(100.dp),
+                painter = painterResource(id = R.drawable.small_cloud),
                 contentDescription = null,
-                modifier = Modifier.size(100.dp))
+            )
         }
-        Box(modifier = Modifier
-            .fillMaxSize()
-            .padding(top = 20.dp, start = 20.dp)){
-            Image(painter = painterResource(id = R.drawable.middle_cloud),
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(top = 20.dp, start = 20.dp)
+        ){
+            Image(
+                modifier = Modifier.size(150.dp),
+                painter = painterResource(id = R.drawable.middle_cloud),
                 contentDescription = null,
-                modifier = Modifier.size(150.dp))
-            Image(painter = painterResource(id = R.drawable.middle_cloud_line),
+            )
+            Image(
+                modifier = Modifier
+                    .size(150.dp)
+                    .offset(-5.dp, -5.dp),
+                painter = painterResource(id = R.drawable.middle_cloud_line),
                 contentDescription = null,
-                modifier = Modifier.size(150.dp))
+            )
         }
-        Box(modifier = Modifier
-            .fillMaxSize()
-            .padding(top = 90.dp, start = 160.dp)){
-            Image(painter = painterResource(id = R.drawable.large_cloud),
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(top = 90.dp, start = 160.dp)
+        ){
+            Image(
+                painter = painterResource(id = R.drawable.large_cloud),
                 contentDescription = null,
-                modifier = Modifier.size(200.dp))
-            Image(painter = painterResource(id = R.drawable.large_cloud_line),
+                modifier = Modifier.size(200.dp)
+            )
+            Image(
+                modifier = Modifier
+                    .size(200.dp)
+                    .offset(-5.dp, -5.dp),
+                painter = painterResource(id = R.drawable.large_cloud_line),
                 contentDescription = null,
-                modifier = Modifier.size(200.dp))
+            )
         }
     }
 }
 
 @Composable
 private fun ColumnScope.Description(){
-    Box(modifier = Modifier.weight(1f)){
-        Column(modifier = Modifier.padding(top = 40.dp)) {
+    Box(
+        modifier = Modifier.weight(1f)
+    ){
+        Column(
+            modifier = Modifier.padding(top = 40.dp)
+        ) {
             Text("'Braini'는",
                 modifier = Modifier
                     .fillMaxWidth()
@@ -103,9 +136,10 @@ private fun ColumnScope.Description(){
                 fontSize = 23.sp,
                 fontWeight = FontWeight.Bold,
             )
-            Text( modifier = Modifier
-                .fillMaxWidth()
-                .padding(start = 30.dp,),
+            Text(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 30.dp,),
                 color = Color.White,
                 fontSize = 23.sp,
                 fontWeight = FontWeight.Bold,
@@ -119,30 +153,40 @@ private fun ColumnScope.Description(){
 
 @Composable
 private fun ColumnScope.Buttons(){
-    Box(modifier = Modifier.weight(1f)){
-        Column(modifier = Modifier
-            .fillMaxWidth()
-            .padding(top = 50.dp),
-            horizontalAlignment = Alignment.CenterHorizontally) {
-            Button(onClick = { /*TODO*/ },
+    Box(
+        modifier = Modifier.weight(1f)
+    ){
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 50.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Button(
+                onClick = { /*TODO*/ },
                 modifier = Modifier.width(320.dp),
                 colors = ButtonDefaults.buttonColors(Color.White),
                 shape = RoundedCornerShape(15.dp)
             ) {
-                Text(text = stringResource(R.string.login_button),
+                Text(
+                    text = stringResource(R.string.login_button),
                     textAlign = TextAlign.Center,
                     color = Color(55, 103, 706),
-                    fontWeight = FontWeight.Bold)
+                    fontWeight = FontWeight.Bold
+                )
             }
-            Button(onClick = { /*TODO*/ },
+            Button(
+                onClick = { /*TODO*/ },
                 modifier = Modifier.width(320.dp),
                 colors = ButtonDefaults.buttonColors(Color.White),
-                shape = RoundedCornerShape(15.dp)) {
-                Text(text = stringResource(R.string.new_user_button),
+                shape = RoundedCornerShape(15.dp)
+            ) {
+                Text(
+                    text = stringResource(R.string.new_user_button),
                     textAlign = TextAlign.Center,
                     color = Color(55,103,706),
-                    fontWeight = FontWeight.Bold)
-
+                    fontWeight = FontWeight.Bold
+                )
             }
         }
     }

--- a/app/src/main/java/com/example/braini/presentation/view/Login.kt
+++ b/app/src/main/java/com/example/braini/presentation/view/Login.kt
@@ -1,5 +1,7 @@
 package com.apptive.braini.view
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
@@ -20,15 +22,25 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navOptions
 import com.apptive.braini.R
+import com.example.braini.presentation.navigation.Screen
+import com.example.braini.presentation.popAndNavigate
+import com.example.braini.presentation.viewmodel.interfaces.ILoginViewModel
+import com.example.braini.presentation.viewmodel.mock.LoginViewModelMock
 
 @Composable
-fun LoginScreen(){
+fun LoginScreen(
+    viewModel: ILoginViewModel = LoginViewModelMock(),
+    navController: NavController
+){
     LoginBackground {
         Header()
         Clouds()
         Description()
-        Buttons()
+        Buttons(viewModel = viewModel, navController = navController)
     }
 }
 
@@ -152,7 +164,10 @@ private fun ColumnScope.Description(){
 
 
 @Composable
-private fun ColumnScope.Buttons(){
+private fun ColumnScope.Buttons(
+    viewModel: ILoginViewModel,
+    navController: NavController
+){
     Box(
         modifier = Modifier.weight(1f)
     ){
@@ -162,8 +177,20 @@ private fun ColumnScope.Buttons(){
                 .padding(top = 50.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
+            val launcher = rememberLauncherForActivityResult(
+                contract = ActivityResultContracts.StartIntentSenderForResult(),
+                onResult = { result ->
+                    viewModel.googleResultListener(
+                        result = result,
+                        onSuccess = { navController.popAndNavigate(Screen.RoomSelect.route) }
+                    )
+                }
+            )
+
             Button(
-                onClick = { /*TODO*/ },
+                onClick = {
+                    viewModel.googleSignIn(launcher = launcher)
+                },
                 modifier = Modifier.width(320.dp),
                 colors = ButtonDefaults.buttonColors(Color.White),
                 shape = RoundedCornerShape(15.dp)
@@ -195,5 +222,6 @@ private fun ColumnScope.Buttons(){
 @Preview
 @Composable
 fun BPreview(){
-    LoginScreen()
+    val navController = rememberNavController()
+    LoginScreen(navController = navController)
 }

--- a/app/src/main/java/com/example/braini/presentation/view/Splash.kt
+++ b/app/src/main/java/com/example/braini/presentation/view/Splash.kt
@@ -12,27 +12,33 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
 import androidx.navigation.NavHostController
 import com.apptive.braini.R
 import com.example.braini.presentation.navigation.Screen
+import com.example.braini.presentation.viewmodel.interfaces.ILoginViewModel
+import com.example.braini.presentation.viewmodel.mock.LoginViewModelMock
 import kotlinx.coroutines.delay
 
 @Composable
-fun AnimatedSplashScreen(navController: NavHostController){
+fun SplashScreen(
+    viewModel: ILoginViewModel = LoginViewModelMock(),
+    navController: NavHostController
+){
     var startAnimation by remember { mutableStateOf(false) }
     val alphaAnim = animateFloatAsState(
         targetValue = if(startAnimation) 1f else 0f,
         animationSpec = tween(
             durationMillis = 3000
         )
-            )
+    )
 
     LaunchedEffect(key1 = true){
         startAnimation = true
         delay(4000)
         navController.popBackStack()
-        navController.navigate(Screen.Login.route)
+
+        if (viewModel.isLoggedIn()) navController.navigate(Screen.RoomSelect.route)
+        else                        navController.navigate(Screen.Login.route)
     }
 
     Splash(alpha = alphaAnim.value)

--- a/app/src/main/java/com/example/braini/presentation/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/com/example/braini/presentation/viewmodel/LoginViewModel.kt
@@ -1,11 +1,11 @@
 package com.example.braini.presentation.viewmodel
 
-import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.ActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import com.example.braini.domain.IntentSenderLauncher
+import com.example.braini.domain.model.Account
 import com.example.braini.domain.utils.AccountManager
 import com.example.braini.domain.utils.GoogleOneTap
 import com.example.braini.presentation.viewmodel.interfaces.ILoginViewModel
@@ -14,13 +14,19 @@ import javax.inject.Inject
 
 @HiltViewModel
 class LoginViewModel @Inject constructor(
-    private val oneTap: GoogleOneTap
+    private val accountManager: AccountManager,
+    private val googleSignIn: GoogleOneTap
 ): ViewModel(), ILoginViewModel {
-    override fun googleResultListener(result: ActivityResult) {
-        oneTap.onActicityResult(result)
+    private val _account = mutableStateOf(accountManager.currentAccount)
+    val account: State<Account> get() = _account
+
+    override fun isLoggedIn(): Boolean = accountManager.isLoggedIn()
+
+    override fun googleResultListener(result: ActivityResult, onSuccess: () -> Unit) {
+        googleSignIn.onActicityResult(result = result, onSuccess = onSuccess)
     }
 
     override fun googleSignIn(launcher: IntentSenderLauncher) {
-        oneTap.beginSignIn(launcher = launcher)
+        googleSignIn.beginSignIn(launcher = launcher)
     }
 }

--- a/app/src/main/java/com/example/braini/presentation/viewmodel/interfaces/ILoginViewModel.kt
+++ b/app/src/main/java/com/example/braini/presentation/viewmodel/interfaces/ILoginViewModel.kt
@@ -4,6 +4,7 @@ import androidx.activity.result.ActivityResult
 import com.example.braini.domain.IntentSenderLauncher
 
 interface ILoginViewModel {
-    fun googleResultListener(result: ActivityResult)
+    fun isLoggedIn(): Boolean
+    fun googleResultListener(result: ActivityResult, onSuccess: () -> Unit = {})
     fun googleSignIn(launcher: IntentSenderLauncher)
 }

--- a/app/src/main/java/com/example/braini/presentation/viewmodel/mock/LoginViewModelMock.kt
+++ b/app/src/main/java/com/example/braini/presentation/viewmodel/mock/LoginViewModelMock.kt
@@ -3,9 +3,14 @@ package com.example.braini.presentation.viewmodel.mock
 import androidx.activity.result.ActivityResult
 import com.example.braini.domain.IntentSenderLauncher
 import com.example.braini.presentation.viewmodel.interfaces.ILoginViewModel
+import kotlin.random.Random
 
 class LoginViewModelMock: ILoginViewModel {
-    override fun googleResultListener(result: ActivityResult) {
+    override fun isLoggedIn(): Boolean {
+        return Random.nextBoolean()
+    }
+
+    override fun googleResultListener(result: ActivityResult, onSuccess: () -> Unit) {
         TODO("Not yet implemented")
     }
 


### PR DESCRIPTION
# 변경점
 - LoginViewModel을 Login.kt, Splash.kt에 적용
   - Splash.kt 화면에서 로그인 여부에 따라 이동할 첫 페이지 결정
   - 로그인 화면에 Google One Tap 적용
 
# 리팩토링
 - modifier 위치, 들여쓰기, 괄호 위치 등 코드 스타일 수정
 
# 스크린샷
![feat_로그인_기능_적용](https://user-images.githubusercontent.com/51331195/167683063-47493f96-19df-4f52-a761-996ebd580b2b.gif)


